### PR TITLE
[fix] Lock down Træfik version to branch 1.7

### DIFF
--- a/tasks/run_container.yml
+++ b/tasks/run_container.yml
@@ -12,7 +12,7 @@
   become: true
   docker_container:
     name: "{{ traefik_container_name }}"
-    image: traefik
+    image: traefik:v1.7
     state: "{{ traefik_docker_state | default('started') }}"
     restart: "{{ traefik_docker_restart | default(false) | bool }}"
     networks: "{{ traefik_docker_networks }}"


### PR DESCRIPTION
Right now, `traefik.toml.j2` is not prepared for Traefik v2.x (running into [this issue](https://stackoverflow.com/q/58477413/435004))
